### PR TITLE
New Function: GetBytesPdf, and added a new Vars map to struct

### DIFF
--- a/goreport.go
+++ b/goreport.go
@@ -34,6 +34,7 @@ type GoReport struct {
 	PageTotal bool
 	Flags     map[string]bool
 	SumWork   map[string]float64
+	Vars      map[string]string
 }
 
 func (r *GoReport) SetFooterYbyFooterHeight(footerHeight float64) {
@@ -76,6 +77,13 @@ func (r *GoReport) Execute(filename string) {
 	r.Convert(true)
 	r.Converter.Pdf.WritePdf(filename)
 }
+
+func (r *GoReport) GetBytesPdf() (ret []byte) {
+	r.Convert(true)
+	ret = r.Converter.Pdf.GetBytesPdf()
+	return
+}
+
 func (r *GoReport) ReplacePageTotal() {
 	if r.PageTotal == false {
 		return
@@ -380,6 +388,7 @@ func CreateGoReport() *GoReport {
 	GoReport.Bands = make(map[string]*Band)
 	GoReport.Converter = new(Converter)
 	GoReport.SumWork = make(map[string]float64)
+	GoReport.Vars = make(map[string]string)
 	GoReport.SumWork["__ft__"] = 0.0 //FooterY
 	GoReport.Flags = make(map[string]bool)
 	GoReport.Flags["NewPageForce"] = false


### PR DESCRIPTION
If you plan to serve a PDF report across a web app, you would want to serve a stream instead of a physical file, thats why I created a Get BytesPdf function, so you can stream a pdf to the client:

		buff := r.GetBytesPdf()
		this.Ctx.Output.Header("Content-Type", "application/pdf")
		this.Ctx.ResponseWriter.Write(buff)

And I added a Vars map to the goreport struct. That is needed if you need a filter to the report, and that map is where u can store the filter value, so you can print that if needed.