### PR TITLE
ajust type to gopdf multiple units

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -124,7 +124,7 @@ func (p *Converter) NewPage(line string, eles []string) {
 	p.Pdf.AddPage()
 }
 func (p *Converter) Start(w float64, h float64) {
-	p.Pdf.Start(gopdf.Config{Unit: "pt",
+	p.Pdf.Start(gopdf.Config{Unit: gopdf.Unit_PT,
 		PageSize: gopdf.Rect{W: w, H: h}}) //595.28, 841.89 = A4
 }
 func (p *Converter) Font(line string, eles []string) {


### PR DESCRIPTION
I've faced this error:
```# github.com/mikeshimura/goreport
../../../.go/src/github.com/mikeshimura/goreport/converter.go:127:33: cannot use "pt" (type string) as type int in field value
make: *** [test] Error 2
```
and then found this commit:
https://github.com/signintech/gopdf/commit/81ad21f15ccf1ff7ca68f7beebee390fc4dbf09f