### PR TITLE
replace deprecated ioutil packages

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -2,10 +2,11 @@ package goreport
 
 import (
 	"fmt"
-	"github.com/signintech/gopdf"
 	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/signintech/gopdf"
 )
 
 type Converter struct {
@@ -18,7 +19,7 @@ type Converter struct {
 
 //var p.ConvPt float64 = 2.834645669
 
-//Read UTF-8 encoding file
+// Read UTF-8 encoding file
 func (p *Converter) ReadFile(fileName string) error {
 	buf, err := ioutil.ReadFile(fileName)
 	if err != nil {
@@ -49,7 +50,7 @@ func (p *Converter) Execute() {
 		case "TC":
 			p.TextColor(line, eles)
 		case "SC":
-            		p.StrokeColor(line, eles)
+			p.StrokeColor(line, eles)
 		case "GF", "GS":
 			p.Grey(line, eles)
 		case "C", "C1", "CR":
@@ -149,9 +150,9 @@ func (p *Converter) TextColor(line string, eles []string) {
 		uint8(AtoiPanic(eles[2], line)), uint8(AtoiPanic(eles[3], line)))
 }
 func (p *Converter) StrokeColor(line string, eles []string) {
-    CheckLength(line, eles, 4)
-    p.Pdf.SetStrokeColor(uint8(AtoiPanic(eles[1], line)),
-        uint8(AtoiPanic(eles[2], line)), uint8(AtoiPanic(eles[3], line)))
+	CheckLength(line, eles, 4)
+	p.Pdf.SetStrokeColor(uint8(AtoiPanic(eles[1], line)),
+		uint8(AtoiPanic(eles[2], line)), uint8(AtoiPanic(eles[3], line)))
 }
 func (p *Converter) Oval(line string, eles []string) {
 	CheckLength(line, eles, 5)

--- a/converter.go
+++ b/converter.go
@@ -2,7 +2,7 @@ package goreport
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -21,7 +21,7 @@ type Converter struct {
 
 // Read UTF-8 encoding file
 func (p *Converter) ReadFile(fileName string) error {
-	buf, err := ioutil.ReadFile(fileName)
+	buf, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/example/complex2.go
+++ b/example/complex2.go
@@ -2,9 +2,11 @@ package example
 
 import (
 	//"fmt"
-	gr "github.com/mikeshimura/goreport"
 	"time"
 	"unicode"
+
+	gr "github.com/mikeshimura/goreport"
+
 	//"io/ioutil"
 	"strconv"
 	"strings"

--- a/goreport.go
+++ b/goreport.go
@@ -2,8 +2,6 @@ package goreport
 
 import (
 	"bytes"
-	//"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -380,7 +378,7 @@ func (r *GoReport) SetPageByDimension(unit string, width float64, height float64
 }
 
 func (r *GoReport) SaveText(fileName string) {
-	ioutil.WriteFile(fileName, []byte(r.Converter.Text), os.ModePerm)
+	os.WriteFile(fileName, []byte(r.Converter.Text), os.ModePerm)
 }
 
 type Band interface {

--- a/goreport.go
+++ b/goreport.go
@@ -3,12 +3,13 @@ package goreport
 import (
 	"bytes"
 	//"fmt"
-	"github.com/mikeshimura/dbflute/df"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/mikeshimura/dbflute/df"
 )
 
 const (
@@ -288,7 +289,7 @@ func (r *GoReport) LineV(x float64, y1 float64, y2 float64) {
 	r.AddLine("LV\t" + Ftoa(x+adj) + "\t" + Ftoa(r.CurrY+y1) + "\t" + Ftoa(r.CurrY+y2))
 }
 
-//SumWork["__lw__"] width adjust
+// SumWork["__lw__"] width adjust
 func (r *GoReport) Rect(x1 float64, y1 float64, x2 float64, y2 float64) {
 	r.AddLine("R\t" + Ftoa(x1) + "\t" + Ftoa(r.CurrY+y1) + "\t" + Ftoa(x2) +
 		"\t" + Ftoa(r.CurrY+y2))
@@ -302,8 +303,8 @@ func (r *GoReport) TextColor(red int, green int, blue int) {
 		"\t" + strconv.Itoa(blue))
 }
 func (r *GoReport) StrokeColor(red int, green int, blue int) {
-    r.AddLine("SC\t" + strconv.Itoa(red) + "\t" + strconv.Itoa(green) +
-        "\t" + strconv.Itoa(blue))
+	r.AddLine("SC\t" + strconv.Itoa(red) + "\t" + strconv.Itoa(green) +
+		"\t" + strconv.Itoa(blue))
 }
 func (r *GoReport) GrayFill(grayScale float64) {
 	r.AddLine("GF\t" + Ftoa(grayScale))
@@ -320,7 +321,7 @@ func (r *GoReport) Var(name string, val string) {
 	r.AddLine("V\t" + name + "\t" + val)
 }
 
-//unit mm pt in  size A4 LTR
+// unit mm pt in  size A4 LTR
 func (r *GoReport) SetPage(size string, unit string, orientation string) {
 	r.SetConv(unit)
 	switch size {
@@ -354,7 +355,7 @@ func (r *GoReport) SetPage(size string, unit string, orientation string) {
 	r.Convert(false)
 }
 
-//unit mm pt in
+// unit mm pt in
 func (r *GoReport) SetConv(ut string) {
 	switch ut {
 	case "mm":

--- a/util.go
+++ b/util.go
@@ -1,8 +1,7 @@
 package goreport
 
 import (
-	//"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -34,7 +33,7 @@ func addCommaSub(s string) string {
 	return res
 }
 func ReadTextFile(filename string, colno int) []interface{} {
-	res, _ := ioutil.ReadFile(filename)
+	res, _ := os.ReadFile(filename)
 	return ReadBytes(res, colno)
 }
 


### PR DESCRIPTION
ioutil seems to be deprecated since go 1.16

ref. https://github.com/golang/go/issues/42026